### PR TITLE
fix: $buttonsArea.find is not a function

### DIFF
--- a/src/ssi-modal/js/ssi-modal.js
+++ b/src/ssi-modal/js/ssi-modal.js
@@ -381,10 +381,10 @@
         if (area !== false) {
             area = (typeof area !== 'undefined' ? $(area) : this.get$window());
             $buttonsArea = area.find('#ssi-buttons');
-            $buttonsArea = $buttonsArea[0];
+            $buttonsArea = $($buttonsArea.get(0));
         }
 
-        if (!$buttonsArea) {
+        if (!$buttonsArea || !$buttonsArea.length) {
             $buttonsArea = $('<div id="ssi-buttons" class="ssi-buttons"><div  id="ssi-leftButtons" class="ssi-leftButtons"></div><div id="ssi-rightButtons" class="ssi-rightButtons"></div></div>');
             if (area) {
                 fixHeight = true;


### PR DESCRIPTION
## Summary by Sourcery

修复在查找模态框组件中的按钮区域时可能出现的错误

错误修复：
- 解决了 $buttonsArea.find 可能不会返回 jQuery 对象，导致 'is not a function' 错误的问题

增强功能：
- 改进按钮区域的选择逻辑，以处理 find 方法可能返回意外结果的情况

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix a potential error when finding buttons area in the modal component

Bug Fixes:
- Resolve an issue where $buttonsArea.find might not return a jQuery object, causing a 'is not a function' error

Enhancements:
- Improve button area selection logic to handle cases where the find method might return an unexpected result

</details>